### PR TITLE
updated web site to 6.4.0.CR1 and removed nearly everything linking t…

### DIFF
--- a/_config/pom.yml
+++ b/_config/pom.yml
@@ -1,6 +1,6 @@
 latestFinal:
     version: 6.3.0.Final
-    distributionZip: http://sourceforge.net/projects/jbpm/files/jBPM%206/jbpm-6.3.0.Final/
+    distributionZip: http://download.jboss.org/jbpm/release/6.3.0.Final
     jbpmBinZip: http://download.jboss.org/jbpm/release/6.3.0.Final/jbpm-6.3.0.Final-bin.zip
     jbpmExamplesZip: http://download.jboss.org/jbpm/release/6.3.0.Final/jbpm-6.3.0.Final-examples.zip
     jbpmInstallerZip: http://download.jboss.org/jbpm/release/6.3.0.Final/jbpm-6.3.0.Final-installer.zip
@@ -22,7 +22,7 @@ latest:
     version: 6.4.0.CR1
     releaseDate: 2016-03-08
 
-    distributionZip: http://sourceforge.net/projects/jbpm/files/jBPM%206/jbpm-6.4.0.CR1/
+    distributionZip: http://download.jboss.org/jbpm/release/6.4.0.CR1
     jbpmBinZip: http://download.jboss.org/jbpm/release/6.4.0.CR1/jbpm-6.4.0.CR1-bin.zip
     jbpmExamplesZip: http://download.jboss.org/jbpm/release/6.4.0.CR1/jbpm-6.4.0.CR1-examples.zip
     jbpmInstallerZip: http://download.jboss.org/jbpm/release/6.4.0.CR1/jbpm-6.4.0.CR1-installer.zip
@@ -39,5 +39,5 @@ latest:
     droolsExpert_documentationPdf: http://docs.jboss.org/drools/release/6.4.0.CR1/drools-docs/pdf/drools-expert-docs.pdf
 
 nightly:
-    version: 7.7.0-SNAPSHOT
+    version: 7.0.0-SNAPSHOT
     jbpmBinaries: http://downloads.jboss.org/jbpm/release/snapshot/master/index.html

--- a/_config/pom.yml
+++ b/_config/pom.yml
@@ -1,34 +1,43 @@
 latestFinal:
     version: 6.3.0.Final
     distributionZip: http://sourceforge.net/projects/jbpm/files/jBPM%206/jbpm-6.3.0.Final/
+    jbpmBinZip: http://download.jboss.org/jbpm/release/6.3.0.Final/jbpm-6.3.0.Final-bin.zip
+    jbpmExamplesZip: http://download.jboss.org/jbpm/release/6.3.0.Final/jbpm-6.3.0.Final-examples.zip
+    jbpmInstallerZip: http://download.jboss.org/jbpm/release/6.3.0.Final/jbpm-6.3.0.Final-installer.zip
+    jbpmInstallerFullZip: http://download.jboss.org/jbpm/release/6.3.0.Final/jbpm-6.3.0.Final-installer-full.zip
+    updatesite: http://download.jboss.org/drools/release/6.3.0.Final/org.drools.updatesite/
     installerChapter: http://docs.jboss.org/jbpm/v6.3/userguide/ch03.html
-    releaseDate: 2015-09-28
-    releaseNotesVersion: http://docs.jboss.org/jbpm/v6.3/userguide/ch25.html
+    releaseDate: 2015-09-25
+    releaseNotesVersion: http://docs.jboss.org/jbpm/release/6.3.0.Final/jbpm-docs/html/ch25.html
 
-    UserGuide: http://docs.jboss.org/jbpm/v6.3/userguide/
-    JavaDocs: http://docs.jboss.org/jbpm/v6.3/javadocs/
+    UserGuide: http://docs.jboss.org/jbpm/release/6.3.0.Final/jbpm-docs/html/
+    JavaDocs: http://docs.jboss.org/drools/release/6.3.0.Final/kie-api-javadoc/index.html
     Archive: http://docs.jboss.org/jbpm/
 
     droolsExpert_documentationHtmlSingle: http://docs.jboss.org/drools/release/6.3.0.Final/drools-docs/html_single/index.html
     droolsExpert_documentationHtml: http://docs.jboss.org/drools/release/6.3.0.Final/drools-docs/html/index.html
     droolsExpert_documentationPdf: http://docs.jboss.org/drools/release/6.3.0.Final/drools-docs/pdf/drools-expert-docs.pdf
 
-# latest.version can be equal to latestFinal.version
 latest:
-    version: 6.3.0.Final
-    distributionZip: http://sourceforge.net/projects/jbpm/files/jBPM%206/jbpm-6.3.0.Final/
-    releaseDate: 2015-09-28
-    releaseNotesVersion: http://docs.jboss.org/jbpm/v6.3/userguide/ch25.html
+    version: 6.4.0.CR1
+    releaseDate: 2016-03-08
 
-    UserGuide: http://docs.jboss.org/jbpm/v6.3/userguide/
+    distributionZip: http://sourceforge.net/projects/jbpm/files/jBPM%206/jbpm-6.4.0.CR1/
+    jbpmBinZip: http://download.jboss.org/jbpm/release/6.4.0.CR1/jbpm-6.4.0.CR1-bin.zip
+    jbpmExamplesZip: http://download.jboss.org/jbpm/release/6.4.0.CR1/jbpm-6.4.0.CR1-examples.zip
+    jbpmInstallerZip: http://download.jboss.org/jbpm/release/6.4.0.CR1/jbpm-6.4.0.CR1-installer.zip
+    updatesite: http://download.jboss.org/drools/release/6.4.0.CR1/org.drools.updatesite-6.4.0.CR1
+
+    releaseNotesVersion: http://docs.jboss.org/jbpm/release/6.4.0.CR1/jbpm-docs/html/ch25.html
+
+    UserGuide: http://docs.jboss.org/jbpm/release/6.4.0.CR1/jbpm-docs/html/
+    JavaDocs: http://docs.jboss.org/drools/release/6.4.0.CR1/kie-api-javadoc/index.html
     Nightly: https://jenkins-kieci.rhcloud.com/job/kie-docs/lastStableBuild/artifact/jbpm-docs/target/docbook/publish/en-US/html/index.html
 
-    droolsExpert_documentationHtmlSingle: http://docs.jboss.org/drools/release/6.3.0.Final/drools-docs/html_single/index.html
-    droolsExpert_documentationHtml: http://docs.jboss.org/drools/release/6.3.0.Final/drools-docs/html/index.html
-    droolsExpert_documentationPdf: http://docs.jboss.org/drools/release/6.3.0.Final/drools-docs/pdf/drools-expert-docs.pdf
+    droolsExpert_documentationHtmlSingle: http://docs.jboss.org/drools/release/6.4.0.CR1/drools-docs/html_single/index.html
+    droolsExpert_documentationHtml: http://docs.jboss.org/drools/release/6.4.0.CR1/drools-docs/html/index.html
+    droolsExpert_documentationPdf: http://docs.jboss.org/drools/release/6.4.0.CR1/drools-docs/pdf/drools-expert-docs.pdf
 
 nightly:
-    version: 6.4.0-SNAPSHOT
-    distributionZip: http://downloads.jboss.org/jbpm/release/snapshot/master/index.html
-
-    documentationHtmlSingle: https://hudson.jboss.org/hudson/job/kie-docs/lastSuccessfulBuild/
+    version: 7.7.0-SNAPSHOT
+    jbpmBinaries: http://downloads.jboss.org/jbpm/release/snapshot/master/index.html

--- a/download/download.adoc
+++ b/download/download.adoc
@@ -3,13 +3,16 @@
 :page-interpolate: true
 :showtitle:
 
-== Final releases
+== Latest Final version: #{site.pom.latestFinal.version}
 
-=== Distribution zip
+The jBPM binaries include documentation, examples and sources.
 
-The jBPM distribution zip includes binaries, documentation, examples and sources.
-
-* image:download.png[] *#{site.pom.latestFinal.distributionZip}[Download jBPM #{site.pom.latestFinal.version}]*
+* image:download.png[] Download jBPM #{site.pom.latestFinal.version} binaries
+** #{site.pom.latestFinal.jbpmBinZip}[jBPM #{site.pom.latestFinal.version}-bin.zip]
+** #{site.pom.latestFinal.jbpmExamplesZip}[jBPM #{site.pom.latestFinal.version}-examples.zip]
+** #{site.pom.latestFinal.jbpmInstallerZip}[jBPM #{site.pom.latestFinal.version}-installer.zip]
+** #{site.pom.latestFinal.jbpmInstallerFullZip}[jBPM #{site.pom.latestFinal.version}-installer-full.zip]
+** #{site.pom.latestFinal.updatesite}[updatesite #{site.pom.latestFinal.version}]
 ** #{site.pom.latestFinal.releaseNotesVersion}[Release notes]
 ** License: link:../code/license.html[ASL 2.0]
 ** Release date: `#{site.pom.latestFinal.releaseDate}`
@@ -47,7 +50,7 @@ More info at http://blog.athico.com/2015/06/drools-jbpm-get-dockerized.html[this
 
 '''
 
-=== jBPM #{site.pom.latest.version}
+=== Latest development version: #{site.pom.latest.version}
 
 *Non-Final releases are the best way to test drive new features and API's
 to provide feedback before we lock down the API with a Final release.*
@@ -60,8 +63,12 @@ An Alpha can be unstable.
 A Beta should work (it passes automated testing), but its new API's might still change in the next release.
 A CR should be almost identical to the Final release.
 
-* image:download.png[] #{site.pom.latest.distributionZip}[Download jBPM #{site.pom.latest.version}]
-** #{site.pom.latestFinal.releaseNotesVersion}[Release notes]
+* image:download.png[] Download jBPM #{site.pom.latest.version} binaries
+** #{site.pom.latest.jbpmBinZip}[Download jBPM #{site.pom.latest.version}-bin.zip]
+** #{site.pom.latest.jbpmExamplesZip}[Download jBPM #{site.pom.latest.version}-examples.zip]
+** #{site.pom.latest.jbpmInstallerZip}[Download jBPM #{site.pom.latest.version}-installer.zip]
+** #{site.pom.latest.updatesite}[updatesite #{site.pom.latest.version}]
+** #{site.pom.latest.releaseNotesVersion}[Release notes]
 ** License: link:../code/license.html[ASL 2.0]
 ** Release date: `#{site.pom.latest.releaseDate}`
 
@@ -80,4 +87,4 @@ Or with Maven:
 
 Nightly snapshots are unstable binaries, build by link:../code/continuousIntegration.html[our build server].
 
-* image:download.png[] #{site.pom.nightly.distributionZip}[Download jBPM #{site.pom.nightly.version}]
+* image:download.png[] #{site.pom.nightly.jbpmBinaries}[Download jBPM #{site.pom.nightly.version} binaries]

--- a/download/download.adoc
+++ b/download/download.adoc
@@ -17,7 +17,7 @@ The jBPM binaries include documentation, examples and sources.
 ** License: link:../code/license.html[ASL 2.0]
 ** Release date: `#{site.pom.latestFinal.releaseDate}`
 
-* Older community releases: Check http://sourceforge.net/projects/jbpm/files/[the release archive].
+* Older community releases: Check http://download.jboss.org/jbpm/release/[the release archive].
 
 * Evaluation version of JBoss BPM Suite: Check http://www.jboss.com/downloads/[the product download site].
 

--- a/learn/documentation.adoc
+++ b/learn/documentation.adoc
@@ -7,7 +7,7 @@
 
 * Documentation for jBPM #{site.pom.latestFinal.version}
   ** jBPM User Guide #{site.pom.latestFinal.version}: #{site.pom.latestFinal.UserGuide}[HTML]
-  ** jBPM JavaDocs #{site.pom.latestFinal.version}: #{site.pom.latestFinal.JavaDocs}[Link]
+  ** jBPM JavaDocs #{site.pom.latestFinal.version}: #{site.pom.latestFinal.JavaDocs}[HTML]
 
   
 * Older community documentation: #{site.pom.latestFinal.Archive}[Check the documentation archive].
@@ -21,5 +21,9 @@
 
 * Documentation for jBPM #{site.pom.latest.version}
   ** jBPM User Guide #{site.pom.latest.version}: #{site.pom.latest.UserGuide}[HTML]
+  ** jBPM JavaDocs #{site.pom.latest.version}: #{site.pom.latest.JavaDocs}[HTML]
+
+=== Nightly builds
+
   ** jBPM Nightly snapshots: #{site.pom.latest.Nightly}[HTML]  
 


### PR DESCRIPTION
Please review this PR 
The web is not yet published, first you have to look if it is OK like this.
There is still a thing that does have to do eng-ops. When a directory on filemgmt.jboss.org for jbpm has the right permission the last link to sourceforge https://sourceforge.net/projects/jbpm/files/jBPM%206/ can be removed.